### PR TITLE
メンテナンスページの追加

### DIFF
--- a/docs/adr/0001-maintenance-mode-edge-config.md
+++ b/docs/adr/0001-maintenance-mode-edge-config.md
@@ -1,0 +1,21 @@
+# ADR 0001: Edge Config によるメンテナンス表示
+
+## Status
+
+Accepted
+
+## Context
+
+Vercel Edge Config に `{ "isInMaintenanceMode": true }` が設定されている間、通常コンテンツではなくメンテナンス中である旨の画面を表示したい。
+
+## Decision
+
+`src/middleware.ts` で `@vercel/edge-config` の `get("isInMaintenanceMode")` を読み、値が `true` の場合は `/maintenance` に rewrite する。静的アセット、Next.js 内部アセット、API、`/maintenance` 自身は対象外にする。
+
+Edge Config の読み取りに失敗した場合は通常表示にフォールバックする。設定や一時的な読み取り失敗によって意図せずサイト全体が停止するリスクを避けるため。
+
+## Consequences
+
+- Edge Config の値を `true` にすると全通常ページでメンテナンス画面が表示される。
+- 値を `false` にする、またはキーを削除すると通常表示に戻る。
+- `/maintenance` は直接アクセス可能だが、検索エンジン向けに `noindex` を設定する。

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,9 @@
+# Glossary
+
+## Edge Config
+
+Vercel が提供する低レイテンシの設定ストア。このプロジェクトでは `isInMaintenanceMode` を読み、メンテナンス表示の切り替えに使う。
+
+## Maintenance mode
+
+通常ページへのアクセス時に、サイト更新中であることを伝える `/maintenance` を表示する状態。Edge Config の `isInMaintenanceMode` が `true` の場合に有効になる。

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@types/marked": "^6.0.0",
         "@typescript-eslint/eslint-plugin": "^7.14.1",
         "@typescript-eslint/parser": "^7.14.1",
+        "@vercel/edge-config": "^1.4.3",
         "eslint-config-prettier": "^9.1.0",
         "framer-motion": "^11.0.25",
         "html-to-text": "^9.0.5",
@@ -1137,6 +1138,7 @@
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-2.9.2.tgz",
       "integrity": "sha512-To/Z92oHpIE+4nk11uVMWqo2GGRS86coeMmjxtpnErmWRdLcp1WVCVRAvn+ZwpLiNR+reWFr2FFqJRsREuZdAg==",
+      "peer": true,
       "dependencies": {
         "@chakra-ui/shared-utils": "2.0.5",
         "csstype": "^3.1.2",
@@ -1161,6 +1163,7 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/@chakra-ui/system/-/system-2.6.2.tgz",
       "integrity": "sha512-EGtpoEjLrUu4W1fHD+a62XR+hzC5YfsWm+6lO0Kybcga3yYEij9beegO0jZgug27V+Rf7vns95VPVP6mFd/DEQ==",
+      "peer": true,
       "dependencies": {
         "@chakra-ui/color-mode": "2.2.0",
         "@chakra-ui/object-utils": "2.1.0",
@@ -1399,6 +1402,7 @@
       "version": "11.11.4",
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.4.tgz",
       "integrity": "sha512-t8AjMlF0gHpvvxk5mAtCqR4vmxiGHCeJBaQO6gncUSdklELOgtwjerNY2yuJNfwnc6vi16U/+uMF+afIawJ9iw==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.11.0",
@@ -1439,6 +1443,7 @@
       "version": "11.11.5",
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.11.5.tgz",
       "integrity": "sha512-/ZjjnaNKvuMPxcIiUkf/9SHoG4Q196DRl1w82hQ3WCsjo1IUR8uaGWrC6a87CrYAW0Kb/pK7hk8BnLgLRi9KoQ==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.11.0",
@@ -1895,6 +1900,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.74.tgz",
       "integrity": "sha512-9AEqNZZyBx8OdZpxzQlaFEVCSFUM2YXJH46yPOiOpm078k6ZLOCcuAzGum/zK8YBwY+dbahVNbHrbgrAwIRlqw==",
       "devOptional": true,
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1945,6 +1951,7 @@
       "version": "7.14.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.14.1.tgz",
       "integrity": "sha512-8lKUOebNLcR0D7RvlcloOacTOWzOqemWEWkKSVpMZVF/XVcwjPR+3MD08QzbW9TCGJ+DwIc6zUSGZ9vd8cO1IA==",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.14.1",
         "@typescript-eslint/types": "7.14.1",
@@ -2113,6 +2120,36 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
     },
+    "node_modules/@vercel/edge-config": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@vercel/edge-config/-/edge-config-1.4.3.tgz",
+      "integrity": "sha512-8vTDATodRrH49wMzKEjZ8/5H2qs1aPkD0uRK585f/Fx4YN2wfHfY/3td9OFrh+gdnCq07z8A5f0hoY6xhBcPkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@vercel/edge-config-fs": "0.1.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.7.0",
+        "next": ">=1"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/edge-config-fs": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/edge-config-fs/-/edge-config-fs-0.1.0.tgz",
+      "integrity": "sha512-NRIBwfcS0bUoUbRWlNGetqjvLSwgYH/BqKqDN7vK1g32p7dN96k0712COgaz6VFizAm9b0g6IG6hR6+hc0KCPg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@zag-js/dom-query": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-0.16.0.tgz",
@@ -2135,6 +2172,7 @@
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3150,6 +3188,7 @@
       "version": "8.57.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3440,6 +3479,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
       "integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.7",
         "array.prototype.findlastindex": "^1.2.3",
@@ -3864,6 +3904,7 @@
       "version": "11.0.25",
       "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.0.25.tgz",
       "integrity": "sha512-mRt7vQGzA7++wTgb+PW1TrlXXgndqR6hCiJ48fXr2X9alte2hPQiAq556HRwDCt0Q5X98MNvcSe4KUa27Gm5Lg==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -5292,6 +5333,7 @@
       "version": "14.1.4",
       "resolved": "https://registry.npmjs.org/next/-/next-14.1.4.tgz",
       "integrity": "sha512-1WTaXeSrUwlz/XcnhGTY7+8eiaFvdet5z9u3V2jb+Ek1vFo0VhHKSAIJvDWfQpttWjnyw14kBeq28TPq7bTeEQ==",
+      "peer": true,
       "dependencies": {
         "@next/env": "14.1.4",
         "@swc/helpers": "0.5.2",
@@ -5800,6 +5842,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5822,6 +5865,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -6753,6 +6797,7 @@
       "version": "5.4.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.4.tgz",
       "integrity": "sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6843,6 +6888,7 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/valtio/-/valtio-1.13.2.tgz",
       "integrity": "sha512-Qik0o+DSy741TmkqmRfjq+0xpZBXi/Y6+fXZLn0xNF1z/waFMbE3rkivv5Zcf9RrMUp6zswf2J7sbh2KBlba5A==",
+      "peer": true,
       "dependencies": {
         "derive-valtio": "0.1.0",
         "proxy-compare": "2.6.0",
@@ -7916,6 +7962,7 @@
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/@chakra-ui/styled-system/-/styled-system-2.9.2.tgz",
       "integrity": "sha512-To/Z92oHpIE+4nk11uVMWqo2GGRS86coeMmjxtpnErmWRdLcp1WVCVRAvn+ZwpLiNR+reWFr2FFqJRsREuZdAg==",
+      "peer": true,
       "requires": {
         "@chakra-ui/shared-utils": "2.0.5",
         "csstype": "^3.1.2",
@@ -7935,6 +7982,7 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/@chakra-ui/system/-/system-2.6.2.tgz",
       "integrity": "sha512-EGtpoEjLrUu4W1fHD+a62XR+hzC5YfsWm+6lO0Kybcga3yYEij9beegO0jZgug27V+Rf7vns95VPVP6mFd/DEQ==",
+      "peer": true,
       "requires": {
         "@chakra-ui/color-mode": "2.2.0",
         "@chakra-ui/object-utils": "2.1.0",
@@ -8127,6 +8175,7 @@
       "version": "11.11.4",
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.4.tgz",
       "integrity": "sha512-t8AjMlF0gHpvvxk5mAtCqR4vmxiGHCeJBaQO6gncUSdklELOgtwjerNY2yuJNfwnc6vi16U/+uMF+afIawJ9iw==",
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.11.0",
@@ -8159,6 +8208,7 @@
       "version": "11.11.5",
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.11.5.tgz",
       "integrity": "sha512-/ZjjnaNKvuMPxcIiUkf/9SHoG4Q196DRl1w82hQ3WCsjo1IUR8uaGWrC6a87CrYAW0Kb/pK7hk8BnLgLRi9KoQ==",
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.11.0",
@@ -8462,6 +8512,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.74.tgz",
       "integrity": "sha512-9AEqNZZyBx8OdZpxzQlaFEVCSFUM2YXJH46yPOiOpm078k6ZLOCcuAzGum/zK8YBwY+dbahVNbHrbgrAwIRlqw==",
       "devOptional": true,
+      "peer": true,
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -8496,6 +8547,7 @@
       "version": "7.14.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.14.1.tgz",
       "integrity": "sha512-8lKUOebNLcR0D7RvlcloOacTOWzOqemWEWkKSVpMZVF/XVcwjPR+3MD08QzbW9TCGJ+DwIc6zUSGZ9vd8cO1IA==",
+      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "7.14.1",
         "@typescript-eslint/types": "7.14.1",
@@ -8587,6 +8639,19 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
     },
+    "@vercel/edge-config": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@vercel/edge-config/-/edge-config-1.4.3.tgz",
+      "integrity": "sha512-8vTDATodRrH49wMzKEjZ8/5H2qs1aPkD0uRK585f/Fx4YN2wfHfY/3td9OFrh+gdnCq07z8A5f0hoY6xhBcPkg==",
+      "requires": {
+        "@vercel/edge-config-fs": "0.1.0"
+      }
+    },
+    "@vercel/edge-config-fs": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/edge-config-fs/-/edge-config-fs-0.1.0.tgz",
+      "integrity": "sha512-NRIBwfcS0bUoUbRWlNGetqjvLSwgYH/BqKqDN7vK1g32p7dN96k0712COgaz6VFizAm9b0g6IG6hR6+hc0KCPg=="
+    },
     "@zag-js/dom-query": {
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-0.16.0.tgz",
@@ -8608,7 +8673,8 @@
     "acorn": {
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg=="
+      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+      "peer": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -9349,6 +9415,7 @@
       "version": "8.57.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
+      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -9550,6 +9617,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
       "integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "array-includes": "^3.1.7",
         "array.prototype.findlastindex": "^1.2.3",
@@ -9873,6 +9941,7 @@
       "version": "11.0.25",
       "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.0.25.tgz",
       "integrity": "sha512-mRt7vQGzA7++wTgb+PW1TrlXXgndqR6hCiJ48fXr2X9alte2hPQiAq556HRwDCt0Q5X98MNvcSe4KUa27Gm5Lg==",
+      "peer": true,
       "requires": {
         "tslib": "^2.4.0"
       }
@@ -10821,6 +10890,7 @@
       "version": "14.1.4",
       "resolved": "https://registry.npmjs.org/next/-/next-14.1.4.tgz",
       "integrity": "sha512-1WTaXeSrUwlz/XcnhGTY7+8eiaFvdet5z9u3V2jb+Ek1vFo0VhHKSAIJvDWfQpttWjnyw14kBeq28TPq7bTeEQ==",
+      "peer": true,
       "requires": {
         "@next/env": "14.1.4",
         "@next/swc-darwin-arm64": "14.1.4",
@@ -11136,6 +11206,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0"
       }
@@ -11152,6 +11223,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -11765,7 +11837,8 @@
     "typescript": {
       "version": "5.4.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.4.tgz",
-      "integrity": "sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw=="
+      "integrity": "sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==",
+      "peer": true
     },
     "unbox-primitive": {
       "version": "1.0.2",
@@ -11820,6 +11893,7 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/valtio/-/valtio-1.13.2.tgz",
       "integrity": "sha512-Qik0o+DSy741TmkqmRfjq+0xpZBXi/Y6+fXZLn0xNF1z/waFMbE3rkivv5Zcf9RrMUp6zswf2J7sbh2KBlba5A==",
+      "peer": true,
       "requires": {
         "derive-valtio": "0.1.0",
         "proxy-compare": "2.6.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/marked": "^6.0.0",
     "@typescript-eslint/eslint-plugin": "^7.14.1",
     "@typescript-eslint/parser": "^7.14.1",
+    "@vercel/edge-config": "^1.4.3",
     "eslint-config-prettier": "^9.1.0",
     "framer-motion": "^11.0.25",
     "html-to-text": "^9.0.5",

--- a/src/app/maintenance/maintenance.module.css
+++ b/src/app/maintenance/maintenance.module.css
@@ -1,0 +1,71 @@
+.main {
+  display: flex;
+  min-height: 100vh;
+  align-items: center;
+  justify-content: center;
+  background:
+    linear-gradient(135deg, rgba(220, 255, 220, 0.92), rgba(246, 251, 255, 0.96)),
+    #dcffdc;
+  padding: 3rem 1.5rem;
+}
+
+.panel {
+  display: flex;
+  width: min(100%, 42rem);
+  flex-direction: column;
+  align-items: center;
+  border: 1px solid rgba(30, 68, 52, 0.18);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.82);
+  padding: 3rem 2rem;
+  text-align: center;
+  box-shadow: 0 18px 60px rgba(30, 68, 52, 0.12);
+}
+
+.logo {
+  height: auto;
+  width: 7.5rem;
+}
+
+.label {
+  margin: 2rem 0 0.75rem;
+  color: #436052;
+  font-size: 0.9rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.title {
+  margin: 0;
+  color: #16251d;
+  font-size: 2rem;
+  font-weight: 800;
+  line-height: 1.4;
+}
+
+.message {
+  max-width: 32rem;
+  margin: 1.2rem 0 0;
+  color: #34463c;
+  font-size: 1.05rem;
+  line-height: 1.9;
+}
+
+@media (max-width: 700px) {
+  .main {
+    padding: 2rem 1rem;
+  }
+
+  .panel {
+    padding: 2.5rem 1.25rem;
+  }
+
+  .title {
+    font-size: 1.5rem;
+  }
+
+  .message {
+    font-size: 1rem;
+  }
+}

--- a/src/app/maintenance/page.tsx
+++ b/src/app/maintenance/page.tsx
@@ -1,0 +1,35 @@
+import type { Metadata } from "next";
+import Image from "next/image";
+import styles from "./maintenance.module.css";
+
+export const metadata: Metadata = {
+  title: "メンテナンス中 | m_yuya's monologue",
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export default function MaintenancePage() {
+  return (
+    <main className={styles.main}>
+      <section className={styles.panel} aria-labelledby="maintenance-title">
+        <Image
+          className={styles.logo}
+          src="/monologue.png"
+          alt="m_yuya's monologue"
+          width={120}
+          height={82}
+          priority
+        />
+        <p className={styles.label}>Maintenance</p>
+        <h1 id="maintenance-title" className={styles.title}>
+          現在メンテナンス中です
+        </h1>
+        <p className={styles.message}>
+          サイトの更新作業を行っています。しばらく時間をおいてから再度アクセスしてください。
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,35 @@
+import { get } from "@vercel/edge-config";
+import { NextResponse, type NextRequest } from "next/server";
+
+const MAINTENANCE_PATH = "/maintenance";
+const PUBLIC_FILE = /\.(.*)$/;
+
+export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  if (pathname === MAINTENANCE_PATH || PUBLIC_FILE.test(pathname)) {
+    return NextResponse.next();
+  }
+
+  try {
+    const isInMaintenanceMode = await get<boolean>("isInMaintenanceMode");
+
+    if (isInMaintenanceMode === true) {
+      const url = request.nextUrl.clone();
+      url.pathname = MAINTENANCE_PATH;
+      url.search = "";
+
+      const response = NextResponse.rewrite(url, { status: 503 });
+      response.headers.set("Retry-After", "3600");
+      return response;
+    }
+  } catch {
+    return NextResponse.next();
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/((?!api|_next/static|_next/image).*)"],
+};


### PR DESCRIPTION
## Summary

- Add Edge Config based maintenance mode routing in `src/middleware.ts`.
- Add a `/maintenance` page with noindex metadata and responsive styling.
- Add a short ADR and glossary entry documenting the maintenance mode behavior.

## Impact

When Vercel Edge Config contains `{ "isInMaintenanceMode": true }`, normal page requests are rewritten to `/maintenance` with a 503 response and `Retry-After` header. Static assets, Next.js internal assets, API routes, and `/maintenance` itself are excluded.

If Edge Config cannot be read, the middleware falls back to normal page rendering to avoid accidentally taking the site down.

## Validation

- `npm run lint`
- `npm run build`
- `curl -I http://localhost:3000/maintenance`
- `curl -I http://localhost:3000/`
